### PR TITLE
エラーハンドリングを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,7 +90,7 @@ playground.xcworkspace
 
 # Carthage
 # Add this line if you want to avoid checking in source code from Carthage dependencies.
-# Carthage/Checkouts
+Carthage/Checkouts
 
 Carthage/Build/
 

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -26,6 +26,10 @@ opt_in_rules:
   - vertical_whitespace_between_cases
   - vertical_whitespace_closing_braces
   - vertical_whitespace_opening_braces
+  
+excluded:
+  # Carthage でインストールしたライブラリは除外
+  - Carthage
 
 force_cast: warning
 

--- a/Cartfile
+++ b/Cartfile
@@ -1,0 +1,1 @@
+github "Daltron/NotificationBanner" "master"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,0 +1,3 @@
+github "Daltron/NotificationBanner" "2ce5c49d8ee4865f01a3ce3bbe078664c78c7a3c"
+github "SnapKit/SnapKit" "5.0.1"
+github "cbpowell/MarqueeLabel" "4.1.0"

--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		3D7D69A5268388FF00FE6E6F /* NotificationBanner.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D7D69A0268388FF00FE6E6F /* NotificationBanner.xcframework */; };
 		3D7D69A6268388FF00FE6E6F /* NotificationBanner.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3D7D69A0268388FF00FE6E6F /* NotificationBanner.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		3D7D69AA2683896C00FE6E6F /* StatusNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D7D69A92683896C00FE6E6F /* StatusNotification.swift */; };
+		3D7D69AC26838A6500FE6E6F /* ErrorMessageBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D7D69AB26838A6500FE6E6F /* ErrorMessageBuilder.swift */; };
 		3DE652C626802CFC005396F3 /* SearchRepositoryDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DE652C526802CFC005396F3 /* SearchRepositoryDataModel.swift */; };
 		3DE652CC2680B696005396F3 /*  SearchRepositoryContract.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DE652CB2680B696005396F3 /*  SearchRepositoryContract.swift */; };
 		3DE652D22680BD0D005396F3 /* SearchRepositoryPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DE652D12680BD0D005396F3 /* SearchRepositoryPresenter.swift */; };
@@ -79,6 +80,7 @@
 		3D7D699F268388FF00FE6E6F /* MarqueeLabel.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = MarqueeLabel.xcframework; path = Carthage/Build/MarqueeLabel.xcframework; sourceTree = "<group>"; };
 		3D7D69A0268388FF00FE6E6F /* NotificationBanner.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = NotificationBanner.xcframework; path = Carthage/Build/NotificationBanner.xcframework; sourceTree = "<group>"; };
 		3D7D69A92683896C00FE6E6F /* StatusNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusNotification.swift; sourceTree = "<group>"; };
+		3D7D69AB26838A6500FE6E6F /* ErrorMessageBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ErrorMessageBuilder.swift; sourceTree = "<group>"; };
 		3DE652C526802CFC005396F3 /* SearchRepositoryDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRepositoryDataModel.swift; sourceTree = "<group>"; };
 		3DE652CB2680B696005396F3 /*  SearchRepositoryContract.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = " SearchRepositoryContract.swift"; sourceTree = "<group>"; };
 		3DE652D12680BD0D005396F3 /* SearchRepositoryPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRepositoryPresenter.swift; sourceTree = "<group>"; };
@@ -164,6 +166,7 @@
 			isa = PBXGroup;
 			children = (
 				3D7D69A92683896C00FE6E6F /* StatusNotification.swift */,
+				3D7D69AB26838A6500FE6E6F /* ErrorMessageBuilder.swift */,
 			);
 			path = Util;
 			sourceTree = "<group>";
@@ -459,6 +462,7 @@
 				3DE652CC2680B696005396F3 /*  SearchRepositoryContract.swift in Sources */,
 				BFD945E3244DC5E80012785A /* SearchRepositoryViewController.swift in Sources */,
 				3DE652D22680BD0D005396F3 /* SearchRepositoryPresenter.swift in Sources */,
+				3D7D69AC26838A6500FE6E6F /* ErrorMessageBuilder.swift in Sources */,
 				3D7D69AA2683896C00FE6E6F /* StatusNotification.swift in Sources */,
 				BF0A658D244F2A3B00280FA6 /* DetailRepositoryViewController.swift in Sources */,
 				BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */,

--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -11,6 +11,12 @@
 		3D23281F268358280068825C /* SearchRepositoryResultCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D23281E268358280068825C /* SearchRepositoryResultCell.swift */; };
 		3D232821268361820068825C /* UIColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D232820268361820068825C /* UIColorExtension.swift */; };
 		3D232823268369710068825C /* DetailRepositoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D232822268369710068825C /* DetailRepositoryView.swift */; };
+		3D7D69A1268388FF00FE6E6F /* SnapKit.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D7D699E268388FF00FE6E6F /* SnapKit.xcframework */; };
+		3D7D69A2268388FF00FE6E6F /* SnapKit.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3D7D699E268388FF00FE6E6F /* SnapKit.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		3D7D69A3268388FF00FE6E6F /* MarqueeLabel.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D7D699F268388FF00FE6E6F /* MarqueeLabel.xcframework */; };
+		3D7D69A4268388FF00FE6E6F /* MarqueeLabel.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3D7D699F268388FF00FE6E6F /* MarqueeLabel.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		3D7D69A5268388FF00FE6E6F /* NotificationBanner.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D7D69A0268388FF00FE6E6F /* NotificationBanner.xcframework */; };
+		3D7D69A6268388FF00FE6E6F /* NotificationBanner.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3D7D69A0268388FF00FE6E6F /* NotificationBanner.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		3DE652C626802CFC005396F3 /* SearchRepositoryDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DE652C526802CFC005396F3 /* SearchRepositoryDataModel.swift */; };
 		3DE652CC2680B696005396F3 /*  SearchRepositoryContract.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DE652CB2680B696005396F3 /*  SearchRepositoryContract.swift */; };
 		3DE652D22680BD0D005396F3 /* SearchRepositoryPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DE652D12680BD0D005396F3 /* SearchRepositoryPresenter.swift */; };
@@ -48,10 +54,29 @@
 		};
 /* End PBXContainerItemProxy section */
 
+/* Begin PBXCopyFilesBuildPhase section */
+		3D7D69A7268388FF00FE6E6F /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				3D7D69A6268388FF00FE6E6F /* NotificationBanner.xcframework in Embed Frameworks */,
+				3D7D69A2268388FF00FE6E6F /* SnapKit.xcframework in Embed Frameworks */,
+				3D7D69A4268388FF00FE6E6F /* MarqueeLabel.xcframework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
 		3D23281E268358280068825C /* SearchRepositoryResultCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRepositoryResultCell.swift; sourceTree = "<group>"; };
 		3D232820268361820068825C /* UIColorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIColorExtension.swift; sourceTree = "<group>"; };
 		3D232822268369710068825C /* DetailRepositoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailRepositoryView.swift; sourceTree = "<group>"; };
+		3D7D699E268388FF00FE6E6F /* SnapKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = SnapKit.xcframework; path = Carthage/Build/SnapKit.xcframework; sourceTree = "<group>"; };
+		3D7D699F268388FF00FE6E6F /* MarqueeLabel.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = MarqueeLabel.xcframework; path = Carthage/Build/MarqueeLabel.xcframework; sourceTree = "<group>"; };
+		3D7D69A0268388FF00FE6E6F /* NotificationBanner.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = NotificationBanner.xcframework; path = Carthage/Build/NotificationBanner.xcframework; sourceTree = "<group>"; };
 		3DE652C526802CFC005396F3 /* SearchRepositoryDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRepositoryDataModel.swift; sourceTree = "<group>"; };
 		3DE652CB2680B696005396F3 /*  SearchRepositoryContract.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = " SearchRepositoryContract.swift"; sourceTree = "<group>"; };
 		3DE652D12680BD0D005396F3 /* SearchRepositoryPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRepositoryPresenter.swift; sourceTree = "<group>"; };
@@ -83,7 +108,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				3DE652E02680C1BE005396F3 /* Moya in Frameworks */,
+				3D7D69A5268388FF00FE6E6F /* NotificationBanner.xcframework in Frameworks */,
+				3D7D69A1268388FF00FE6E6F /* SnapKit.xcframework in Frameworks */,
 				3D23281C268354150068825C /* AlamofireImage in Frameworks */,
+				3D7D69A3268388FF00FE6E6F /* MarqueeLabel.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -118,6 +146,16 @@
 				3D232822268369710068825C /* DetailRepositoryView.swift */,
 			);
 			path = ViewComponent;
+			sourceTree = "<group>";
+		};
+		3D7D699D268388FE00FE6E6F /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				3D7D699F268388FF00FE6E6F /* MarqueeLabel.xcframework */,
+				3D7D69A0268388FF00FE6E6F /* NotificationBanner.xcframework */,
+				3D7D699E268388FF00FE6E6F /* SnapKit.xcframework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		3DE652C426802CDC005396F3 /* DataModel */ = {
@@ -192,6 +230,7 @@
 				BFD945F4244DC5EB0012785A /* iOSEngineerCodeCheckTests */,
 				BFD945FF244DC5EB0012785A /* iOSEngineerCodeCheckUITests */,
 				BFD945DC244DC5E80012785A /* Products */,
+				3D7D699D268388FE00FE6E6F /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -251,6 +290,7 @@
 				BFD945D8244DC5E80012785A /* Frameworks */,
 				BFD945D9244DC5E80012785A /* Resources */,
 				3DE652C82680A38B005396F3 /* Run SwiftLint */,
+				3D7D69A7268388FF00FE6E6F /* Embed Frameworks */,
 			);
 			buildRules = (
 			);

--- a/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
+++ b/iOSEngineerCodeCheck.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		3D7D69A4268388FF00FE6E6F /* MarqueeLabel.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3D7D699F268388FF00FE6E6F /* MarqueeLabel.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		3D7D69A5268388FF00FE6E6F /* NotificationBanner.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3D7D69A0268388FF00FE6E6F /* NotificationBanner.xcframework */; };
 		3D7D69A6268388FF00FE6E6F /* NotificationBanner.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3D7D69A0268388FF00FE6E6F /* NotificationBanner.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		3D7D69AA2683896C00FE6E6F /* StatusNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D7D69A92683896C00FE6E6F /* StatusNotification.swift */; };
 		3DE652C626802CFC005396F3 /* SearchRepositoryDataModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DE652C526802CFC005396F3 /* SearchRepositoryDataModel.swift */; };
 		3DE652CC2680B696005396F3 /*  SearchRepositoryContract.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DE652CB2680B696005396F3 /*  SearchRepositoryContract.swift */; };
 		3DE652D22680BD0D005396F3 /* SearchRepositoryPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DE652D12680BD0D005396F3 /* SearchRepositoryPresenter.swift */; };
@@ -77,6 +78,7 @@
 		3D7D699E268388FF00FE6E6F /* SnapKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = SnapKit.xcframework; path = Carthage/Build/SnapKit.xcframework; sourceTree = "<group>"; };
 		3D7D699F268388FF00FE6E6F /* MarqueeLabel.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = MarqueeLabel.xcframework; path = Carthage/Build/MarqueeLabel.xcframework; sourceTree = "<group>"; };
 		3D7D69A0268388FF00FE6E6F /* NotificationBanner.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = NotificationBanner.xcframework; path = Carthage/Build/NotificationBanner.xcframework; sourceTree = "<group>"; };
+		3D7D69A92683896C00FE6E6F /* StatusNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusNotification.swift; sourceTree = "<group>"; };
 		3DE652C526802CFC005396F3 /* SearchRepositoryDataModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRepositoryDataModel.swift; sourceTree = "<group>"; };
 		3DE652CB2680B696005396F3 /*  SearchRepositoryContract.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = " SearchRepositoryContract.swift"; sourceTree = "<group>"; };
 		3DE652D12680BD0D005396F3 /* SearchRepositoryPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRepositoryPresenter.swift; sourceTree = "<group>"; };
@@ -156,6 +158,14 @@
 				3D7D699E268388FF00FE6E6F /* SnapKit.xcframework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		3D7D69A82683895D00FE6E6F /* Util */ = {
+			isa = PBXGroup;
+			children = (
+				3D7D69A92683896C00FE6E6F /* StatusNotification.swift */,
+			);
+			path = Util;
 			sourceTree = "<group>";
 		};
 		3DE652C426802CDC005396F3 /* DataModel */ = {
@@ -247,6 +257,7 @@
 		BFD945DD244DC5E80012785A /* iOSEngineerCodeCheck */ = {
 			isa = PBXGroup;
 			children = (
+				3D7D69A82683895D00FE6E6F /* Util */,
 				3DE652EC2680EA66005396F3 /* Extension */,
 				3DE652E92680DF60005396F3 /* Assembler */,
 				3DE652E12680C24E005396F3 /* API */,
@@ -448,6 +459,7 @@
 				3DE652CC2680B696005396F3 /*  SearchRepositoryContract.swift in Sources */,
 				BFD945E3244DC5E80012785A /* SearchRepositoryViewController.swift in Sources */,
 				3DE652D22680BD0D005396F3 /* SearchRepositoryPresenter.swift in Sources */,
+				3D7D69AA2683896C00FE6E6F /* StatusNotification.swift in Sources */,
 				BF0A658D244F2A3B00280FA6 /* DetailRepositoryViewController.swift in Sources */,
 				BFD945DF244DC5E80012785A /* AppDelegate.swift in Sources */,
 				3DE652D42680BF04005396F3 /* SearchRepositoryModel.swift in Sources */,

--- a/iOSEngineerCodeCheck/SearchRepository/ SearchRepositoryContract.swift
+++ b/iOSEngineerCodeCheck/SearchRepository/ SearchRepositoryContract.swift
@@ -13,6 +13,9 @@ protocol SearchRepositoryPresenterOutput: AnyObject {
     /// リポジトリ詳細画面に遷移する
     /// - parameter repository:詳細表示するリポジトリ
     func transitionToRepositoryDetail(repository: Repository)
+
+    /// エラーメッセージを表示する
+    func showError(message: String)
 }
 
 /// リポジトリ検索Presentation

--- a/iOSEngineerCodeCheck/SearchRepository/SearchRepositoryPresenter.swift
+++ b/iOSEngineerCodeCheck/SearchRepository/SearchRepositoryPresenter.swift
@@ -14,7 +14,7 @@ class SearchRepositoryPresenter: SearchRepositoryPresenterInput {
                 self?.output?.updateRepositories(repositories: repositories)
 
             case let .failure(error):
-                print(error)
+                self?.output?.showError(message: ErrorMessageBuilder.buildErrorMessage(error: error, message: "リポジトリの取得に失敗しました"))
             }
         }
     }

--- a/iOSEngineerCodeCheck/SearchRepository/SearchRepositoryViewController.swift
+++ b/iOSEngineerCodeCheck/SearchRepository/SearchRepositoryViewController.swift
@@ -35,6 +35,10 @@ class SearchRepositoryViewController: UIViewController, SearchRepositoryPresente
         presentDetailRepositoryView(repository: repository)
     }
 
+    func showError(message: String) {
+        StatusNotification.notifyError(message)
+    }
+
     // MARK: Private
     private func presentDetailRepositoryView(repository: Repository) {
         let detailViewController = ModuleAssembler.assembleDetailRepositoryModule(repository: repository)

--- a/iOSEngineerCodeCheck/Util/ErrorMessageBuilder.swift
+++ b/iOSEngineerCodeCheck/Util/ErrorMessageBuilder.swift
@@ -1,0 +1,19 @@
+import Alamofire
+import Foundation
+import Moya
+import UIKit
+
+class ErrorMessageBuilder {
+    static func buildErrorMessage(error: Error, message: String) -> String {
+        var errorMessage = message
+        if let moyaError = error as? MoyaError, let error = ((moyaError.errorUserInfo["NSUnderlyingError"]as? Alamofire.AFError)?.underlyingError as NSError?) {
+            switch error.code {
+            case -1009: // NSURLErrorNotConnectedToInternet
+                errorMessage = message + "(インターネット接続がありません)"
+            default:
+                errorMessage = message
+            }
+        }
+        return errorMessage
+    }
+}

--- a/iOSEngineerCodeCheck/Util/StatusNotification.swift
+++ b/iOSEngineerCodeCheck/Util/StatusNotification.swift
@@ -1,0 +1,22 @@
+import Foundation
+import MarqueeLabel
+import NotificationBanner
+
+/// ユーザーへの状態通知
+struct StatusNotification {
+    /// Error通知
+    static func notifyError(_ message: String, _ file: String = #file, _ function: String = #function, _ line: Int = #line) {
+        let banner = StatusBarNotificationBanner(title: message, style: .danger)
+        if let titleLabel = banner.titleLabel as? MarqueeLabel {
+            titleLabel.type = .left
+            titleLabel.animationDelay = 1
+        }
+        banner.haptic = .heavy
+        banner.duration = 2
+        banner.show()
+    }
+
+    // MARK: - Private
+    private init() {
+    }
+}


### PR DESCRIPTION
APIリクエスト時にエラーが発生した場合、エラーをログに残す程度にとどめていたので、エラーメッセージをバナーで出すようにした。また、機内モード時に発生するネットワークエラーが原因の場合には、ネットワーク接続を確認してもらうように、その旨のメッセージも付け加えた。

- バナーメッセージ
  - ライブラリのNotifivationBannerを導入した。SPM対応していなかったので、Carthageを使って導入した。
  - Carthageを使うにあたって、Carthageでbuildしたものをgit管理しないようにgitigonoreを編集した。
  - 導入したライブラリのコードはswiftlintでのチェックは行わないので、swiftlint.ymlにCarthageのコードは無視するように記述した。
